### PR TITLE
feat: Add private link VPC Endpoint and switch to use it

### DIFF
--- a/lab1/app_instance.tf
+++ b/lab1/app_instance.tf
@@ -29,7 +29,7 @@ resource "aws_instance" "app" {
     "resources/user-data/app-user-data.sh.tftpl",
     {
       squid_proxy_addr         = format("http://%s:3128", aws_network_interface.proxy_private_eth.private_dns_name)
-      ldap_server_dns_endpoint = module.ldap_instance.ldap_nlb_dns_endpoint
+      ldap_server_dns_endpoint = aws_vpc_endpoint.ldap_vpc_endpoint.dns_entry[0]["dns_name"]
     }
   )
   iam_instance_profile = aws_iam_instance_profile.ec2_cw_instance_profile.name

--- a/lab1/ldap_svc_endpoint.tf
+++ b/lab1/ldap_svc_endpoint.tf
@@ -1,0 +1,40 @@
+resource "aws_security_group" "sg_for_ldap_vpc_endpoint" {
+  vpc_id = module.basic_network.vpc_id
+
+  ingress {
+    from_port   = 389
+    to_port     = 389
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 636
+    to_port     = 636
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "all"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_vpc_endpoint" "ldap_vpc_endpoint" {
+  vpc_id            = module.basic_network.vpc_id
+  service_name      = module.ldap_instance.ldap_private_link_svc_name
+  vpc_endpoint_type = "Interface"
+
+  security_group_ids = [
+    aws_security_group.sg_for_ldap_vpc_endpoint.id
+  ]
+
+  subnet_ids = [
+    module.basic_network.private_subnet_id
+  ]
+
+  tags = var.general_tags
+}

--- a/lab1/proxy_instance.tf
+++ b/lab1/proxy_instance.tf
@@ -42,7 +42,7 @@ resource "aws_instance" "proxy" {
   user_data = templatefile(
     "resources/user-data/proxy-user-data.sh.tftpl",
     {
-      ldap_server_dns_endpoint = module.ldap_instance.ldap_nlb_dns_endpoint
+      ldap_server_dns_endpoint = aws_vpc_endpoint.ldap_vpc_endpoint.dns_entry[0]["dns_name"]
     }
   )
   iam_instance_profile = aws_iam_instance_profile.ec2_cw_instance_profile.name

--- a/modules/ldap-instance/output.tf
+++ b/modules/ldap-instance/output.tf
@@ -17,3 +17,7 @@ output "ldap_private_link_svc_id" {
 output "ldap_private_link_svc_arm" {
   value = aws_vpc_endpoint_service.ldap_private_link_svc.arn
 }
+
+output "ldap_private_link_svc_name" {
+  value = aws_vpc_endpoint_service.ldap_private_link_svc.service_name
+}


### PR DESCRIPTION
- Add a VPC Endpoint for LDAP Service in the main private subnet
- Switch LDAP endpoint in user data script of related instances